### PR TITLE
Update IVLS to match the updates in dependency libraries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ bench-utils = { git = "https://github.com/arkworks-rs/utils", default-features =
 ark-relations = { git = "https://github.com/arkworks-rs/snark", default-features = false }
 ark-crypto-primitives = { git = "https://github.com/arkworks-rs/crypto-primitives", branch = "main", default-features = false, features = [ "r1cs" ] }
 ark-r1cs-std = { git = "https://github.com/arkworks-rs/r1cs-std", default-features = false  }
-ark-nonnative-field = { git = "https://github.com/arkworks-rs/nonnative", default-features = false, features = [ "density-optimized" ] }
+ark-nonnative-field = { git = "https://github.com/arkworks-rs/nonnative", default-features = false  }
 
 ark-ed-on-bls12-381 = { git = "https://github.com/arkworks-rs/curves", default-features = false, features = [ "r1cs" ] }
 ark-snark = { git = "https://github.com/arkworks-rs/snark", default-features = false }
@@ -43,8 +43,8 @@ tracing-subscriber = { version = "0.2", default-features = false, optional = tru
 
 ark-groth16 = { git = "https://github.com/arkworks-rs/groth16", default-features = false, features = [ "r1cs" ] }
 ark-gm17 = { git = "https://github.com/arkworks-rs/gm17", default-features = false, features = [ "r1cs" ] }
-ark-marlin = { git = "https://github.com/arkworks-rs/marlin", branch = "constraints", default-features = false, features = [ "density-optimized" ] }
-ark-poly-commit = { git = "https://github.com/arkworks-rs/poly-commit", branch = "constraints", default-features = false, features = [ "r1cs", "density-optimized" ] }
+ark-marlin = { git = "https://github.com/arkworks-rs/marlin", branch = "constraints", default-features = false }
+ark-poly-commit = { git = "https://github.com/arkworks-rs/poly-commit", branch = "constraints", default-features = false, features = [ "r1cs" ] }
 
 [dev-dependencies]
 tracing = { version = "0.1", default-features = false }

--- a/src/building_blocks/crh/poseidon.rs
+++ b/src/building_blocks/crh/poseidon.rs
@@ -57,7 +57,10 @@ impl<RO: Rng + CryptoRng + SeedableRng, F: PrimeField> CRHforMerkleTree
             field_bits_big_endian.reverse();
 
             field_elements.push(
-                F::from_repr(<F::BigInt as BigInteger>::from_bits(&field_bits_big_endian)).unwrap(),
+                F::from_repr(<F::BigInt as BigInteger>::from_bits_be(
+                    &field_bits_big_endian,
+                ))
+                .unwrap(),
             );
         }
 

--- a/src/building_blocks/mt/merkle_sparse_tree/constraints.rs
+++ b/src/building_blocks/mt/merkle_sparse_tree/constraints.rs
@@ -390,7 +390,7 @@ mod test {
     type JubJubMerkleTree = MerkleSparseTree<JubJubMerkleTreeParams>;
 
     fn generate_merkle_tree(leaves: &BTreeMap<u64, [u8; 30]>, use_bad_root: bool) {
-        let mut rng = ark_ff::test_rng();
+        let mut rng = ark_std::test_rng();
 
         let crh_parameters = H::setup(&mut rng).unwrap();
         let tree = JubJubMerkleTree::new(crh_parameters.clone(), leaves).unwrap();
@@ -500,7 +500,7 @@ mod test {
         old_leaves: &BTreeMap<u64, [u8; 2]>,
         new_leaves: &BTreeMap<u64, [u8; 2]>,
     ) {
-        let mut rng = ark_ff::test_rng();
+        let mut rng = ark_std::test_rng();
 
         let crh_parameters = H::setup(&mut rng).unwrap();
         let mut tree = JubJubMerkleTree::new(crh_parameters.clone(), old_leaves).unwrap();

--- a/src/building_blocks/mt/merkle_sparse_tree/mod.rs
+++ b/src/building_blocks/mt/merkle_sparse_tree/mod.rs
@@ -774,7 +774,7 @@ mod test {
     fn generate_merkle_tree_and_test_membership<L: Default + ToBytes + Clone + Eq>(
         leaves: &BTreeMap<u64, L>,
     ) {
-        let mut rng = ark_ff::test_rng();
+        let mut rng = ark_std::test_rng();
 
         let crh_parameters = H::setup(&mut rng).unwrap();
         let tree = JubJubMerkleTree::new(crh_parameters.clone(), leaves).unwrap();
@@ -807,7 +807,7 @@ mod test {
     fn generate_merkle_tree_with_bad_root_and_test_membership<L: Default + ToBytes + Clone + Eq>(
         leaves: &BTreeMap<u64, L>,
     ) {
-        let mut rng = ark_ff::test_rng();
+        let mut rng = ark_std::test_rng();
 
         let crh_parameters = H::setup(&mut rng).unwrap();
         let tree = JubJubMerkleTree::new(crh_parameters.clone(), leaves).unwrap();
@@ -835,7 +835,7 @@ mod test {
         old_leaves: &BTreeMap<u64, L>,
         new_leaves: &BTreeMap<u64, L>,
     ) {
-        let mut rng = ark_ff::test_rng();
+        let mut rng = ark_std::test_rng();
 
         let crh_parameters = H::setup(&mut rng).unwrap();
         let mut tree = JubJubMerkleTree::new(crh_parameters.clone(), old_leaves).unwrap();

--- a/tests/merkle_sparse_tree.rs
+++ b/tests/merkle_sparse_tree.rs
@@ -26,7 +26,7 @@ fn test_merkle_sparse_tree_pedersen() {
 
     type M = SparseMT<Fr, P, HG>;
 
-    let mut rng = ark_ff::test_rng();
+    let mut rng = ark_std::test_rng();
 
     let pp = M::setup(&mut rng).unwrap();
 
@@ -142,7 +142,7 @@ fn test_merkle_sparse_tree_poseidon() {
 
     type M = SparseMT<Fr, P, HG>;
 
-    let mut rng = ark_ff::test_rng();
+    let mut rng = ark_std::test_rng();
 
     let pp = M::setup(&mut rng).unwrap();
 

--- a/tests/verifiable_transition_mnt_big_groth16.rs
+++ b/tests/verifiable_transition_mnt_big_groth16.rs
@@ -74,7 +74,7 @@ type TestPCD = ECCyclePCD<Fr, Fq, PCDGroth16Mnt4>;
 fn test_verifiable_transition_mnt_big_groth16_cycle_pcd() {
     type VC = VCTemplate<TestPCD>;
 
-    let mut rng = ark_ff::test_rng();
+    let mut rng = ark_std::test_rng();
 
     let setup_start = Instant::now();
     let pp = CircuitSpecificSetupIVLSCompiler::circuit_specific_setup(&mut rng).unwrap();

--- a/tests/verifiable_transition_mnt_small_groth16.rs
+++ b/tests/verifiable_transition_mnt_small_groth16.rs
@@ -80,7 +80,7 @@ type TestPCD = ECCyclePCD<Fr, Fq, PCDGroth16Mnt4>;
 fn test_verifiable_transition_mnt_small_groth16_cycle_pcd() {
     type VC = VCTemplate<TestPCD>;
 
-    let mut rng = ark_ff::test_rng();
+    let mut rng = ark_std::test_rng();
 
     let setup_start = Instant::now();
     let pp = CircuitSpecificSetupIVLSCompiler::circuit_specific_setup(&mut rng).unwrap();

--- a/tests/verifiable_transition_mnt_small_marlin.rs
+++ b/tests/verifiable_transition_mnt_small_marlin.rs
@@ -27,7 +27,7 @@ use ark_marlin::{
 use ark_ff::{biginteger::BigInteger320, fields::PrimeField};
 use ark_poly_commit::marlin_pc::{MarlinKZG10, MarlinKZG10Gadget};
 
-use ark_ec::CycleEngine;
+use ark_ec::{CurveCycle, PairingEngine, PairingFriendlyCycle};
 use ark_ivls::building_blocks::crh::poseidon::{
     PoseidonCRHforMerkleTree, PoseidonCRHforMerkleTreeGadget,
 };
@@ -46,16 +46,24 @@ use rand_chacha::ChaChaRng;
 
 #[derive(Copy, Clone, Debug)]
 pub struct Mnt46298Cycle;
-impl CycleEngine for Mnt46298Cycle {
-    type E1 = MNT4_298;
-    type E2 = MNT6_298;
+impl CurveCycle for Mnt46298Cycle {
+    type E1 = <MNT4_298 as PairingEngine>::G1Affine;
+    type E2 = <MNT6_298 as PairingEngine>::G1Affine;
+}
+impl PairingFriendlyCycle for Mnt46298Cycle {
+    type Engine1 = MNT4_298;
+    type Engine2 = MNT6_298;
 }
 
 #[derive(Copy, Clone, Debug)]
 pub struct Mnt64298Cycle;
-impl CycleEngine for Mnt64298Cycle {
-    type E1 = MNT6_298;
-    type E2 = MNT4_298;
+impl CurveCycle for Mnt64298Cycle {
+    type E1 = <MNT6_298 as PairingEngine>::G1Affine;
+    type E2 = <MNT4_298 as PairingEngine>::G1Affine;
+}
+impl PairingFriendlyCycle for Mnt64298Cycle {
+    type Engine1 = MNT6_298;
+    type Engine2 = MNT4_298;
 }
 
 type FS4 = FiatShamirAlgebraicSpongeRng<Fr, Fq, PoseidonSponge<Fq>>;
@@ -135,7 +143,7 @@ type TestPCD = ECCyclePCD<Fr, Fq, PCDMarlin>;
 fn test_verifiable_transition_mnt_small_marlin_cycle_pcd() {
     type VC = VCTemplate<TestPCD>;
 
-    let mut rng = ark_ff::test_rng();
+    let mut rng = ark_std::test_rng();
 
     let setup_start = Instant::now();
     let pp = CircuitSpecificSetupIVLSCompiler::circuit_specific_setup(&mut rng).unwrap();

--- a/tests/verifiable_transition_mnt_small_marlin_universal.rs
+++ b/tests/verifiable_transition_mnt_small_marlin_universal.rs
@@ -28,7 +28,7 @@ use ark_marlin::{
 use ark_ff::{biginteger::BigInteger320, fields::PrimeField};
 use ark_poly_commit::marlin_pc::{MarlinKZG10, MarlinKZG10Gadget};
 
-use ark_ec::CycleEngine;
+use ark_ec::{CurveCycle, PairingEngine, PairingFriendlyCycle};
 use ark_ivls::building_blocks::crh::poseidon::{
     PoseidonCRHforMerkleTree, PoseidonCRHforMerkleTreeGadget,
 };
@@ -46,24 +46,32 @@ use ark_std::time::Instant;
 use rand_chacha::ChaChaRng;
 
 #[derive(Copy, Clone, Debug)]
-pub struct MNT46298Cycle;
-impl CycleEngine for MNT46298Cycle {
-    type E1 = MNT4_298;
-    type E2 = MNT6_298;
+pub struct Mnt46298Cycle;
+impl CurveCycle for Mnt46298Cycle {
+    type E1 = <MNT4_298 as PairingEngine>::G1Affine;
+    type E2 = <MNT6_298 as PairingEngine>::G1Affine;
+}
+impl PairingFriendlyCycle for Mnt46298Cycle {
+    type Engine1 = MNT4_298;
+    type Engine2 = MNT6_298;
 }
 
 #[derive(Copy, Clone, Debug)]
-pub struct MNT64298Cycle;
-impl CycleEngine for MNT64298Cycle {
-    type E1 = MNT6_298;
-    type E2 = MNT4_298;
+pub struct Mnt64298Cycle;
+impl CurveCycle for Mnt64298Cycle {
+    type E1 = <MNT6_298 as PairingEngine>::G1Affine;
+    type E2 = <MNT4_298 as PairingEngine>::G1Affine;
+}
+impl PairingFriendlyCycle for Mnt64298Cycle {
+    type Engine1 = MNT6_298;
+    type Engine2 = MNT4_298;
 }
 
 type FS4 = FiatShamirAlgebraicSpongeRng<Fr, Fq, PoseidonSponge<Fq>>;
 type FS6 = FiatShamirAlgebraicSpongeRng<Fq, Fr, PoseidonSponge<Fr>>;
 
-type PCGadget4 = MarlinKZG10Gadget<MNT64298Cycle, DensePolynomial<Fr>, MNT4PairingVar>;
-type PCGadget6 = MarlinKZG10Gadget<MNT46298Cycle, DensePolynomial<Fq>, MNT6PairingVar>;
+type PCGadget4 = MarlinKZG10Gadget<Mnt64298Cycle, DensePolynomial<Fr>, MNT4PairingVar>;
+type PCGadget6 = MarlinKZG10Gadget<Mnt46298Cycle, DensePolynomial<Fq>, MNT6PairingVar>;
 
 type FSG4 = FiatShamirAlgebraicSpongeRngVar<Fr, Fq, PoseidonSponge<Fq>, PoseidonSpongeVar<Fq>>;
 type FSG6 = FiatShamirAlgebraicSpongeRngVar<Fq, Fr, PoseidonSponge<Fr>, PoseidonSpongeVar<Fr>>;
@@ -136,7 +144,7 @@ type TestPCD = ECCyclePCD<Fr, Fq, PCDMarlin>;
 fn test_verifiable_transition_mnt_small_marlin_universal_cycle_pcd() {
     type VC = VCTemplate<TestPCD>;
 
-    let mut rng = ark_ff::test_rng();
+    let mut rng = ark_std::test_rng();
 
     let bound = MarlinBound {
         max_degree: 2097152,


### PR DESCRIPTION
Many libraries that IVLS depends on, including poly-commit, marlin, and so on, have major updates.

This PR brings IVLS up to date with those libraries.