### PR TITLE
Replace `rand` with `ark_std::rand`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,6 @@ ark-ed-on-bls12-381 = { git = "https://github.com/arkworks-rs/curves", default-f
 ark-snark = { git = "https://github.com/arkworks-rs/snark", default-features = false }
 ark-pcd = { git = "https://github.com/arkworks-rs/pcd", default-features = false }
 
-rand_chacha = { version = "0.2.1", default-features = false }
-rand = { version = "0.7", default-features = false  }
 derivative = { version = "2.0", features = ["use_core"] }
 
 tracing-subscriber = { version = "0.2", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ ark-mnt4-298 = { git = "https://github.com/arkworks-rs/curves", default-features
 ark-mnt6-298 = { git = "https://github.com/arkworks-rs/curves", default-features = false, features = [ "r1cs" ] }
 ark-mnt4-753 = { git = "https://github.com/arkworks-rs/curves", default-features = false, features = [ "curve", "r1cs" ] }
 ark-mnt6-753 = { git = "https://github.com/arkworks-rs/curves", default-features = false, features = [ "r1cs" ] }
+rand_chacha = { version = "0.2", default-features = false }
 
 ###############################################################################
 

--- a/src/building_blocks/crh/bowe_hopwood.rs
+++ b/src/building_blocks/crh/bowe_hopwood.rs
@@ -4,7 +4,7 @@ use ark_ec::{ModelParameters, TEModelParameters};
 use ark_ff::{PrimeField, ToBytes};
 use ark_r1cs_std::bits::uint8::UInt8;
 use ark_r1cs_std::{R1CSVar, ToBytesGadget};
-use rand::{CryptoRng, Rng, SeedableRng};
+use ark_std::rand::{CryptoRng, Rng, SeedableRng};
 
 use crate::gadgets::FpVar;
 use ark_pcd::variable_length_crh::bowe_hopwood::constraints::{

--- a/src/building_blocks/crh/mod.rs
+++ b/src/building_blocks/crh/mod.rs
@@ -3,7 +3,7 @@ use ark_ff::{PrimeField, ToBytes};
 use ark_r1cs_std::eq::EqGadget;
 use ark_r1cs_std::select::CondSelectGadget;
 use ark_r1cs_std::{alloc::AllocVar, bits::uint8::UInt8, R1CSVar, ToBytesGadget};
-use rand::{CryptoRng, Rng};
+use ark_std::rand::{CryptoRng, Rng};
 
 /// The Bowe-Hopwood variant of the Pedersen hash
 pub mod bowe_hopwood;

--- a/src/building_blocks/crh/poseidon.rs
+++ b/src/building_blocks/crh/poseidon.rs
@@ -5,8 +5,8 @@
 use crate::building_blocks::crh::{CRHforMerkleTree, CRHforMerkleTreeGadget};
 use crate::Error;
 use ark_ff::{BigInteger, FpParameters, PrimeField};
+use ark_std::rand::{CryptoRng, Rng, SeedableRng};
 use ark_std::{marker::PhantomData, vec::Vec};
-use rand::{CryptoRng, Rng, SeedableRng};
 
 use crate::gadgets::{FieldVar, FpVar, ToBitsGadget};
 use ark_marlin::fiat_shamir::constraints::AlgebraicSpongeVar;

--- a/src/building_blocks/mt/mod.rs
+++ b/src/building_blocks/mt/mod.rs
@@ -10,11 +10,11 @@ use crate::{
 use ark_r1cs_std::alloc::AllocationMode;
 use ark_relations::r1cs::{ConstraintSystemRef, Namespace};
 use ark_std::collections::BTreeMap;
+use ark_std::rand::{CryptoRng, Rng};
 use ark_std::{
     io::{Result as IoResult, Write},
     string::ToString,
 };
-use rand::{CryptoRng, Rng};
 
 /// implementation of sparse Merkle tree
 pub mod merkle_sparse_tree;

--- a/src/compiler/circuit_specific_setup_compiler.rs
+++ b/src/compiler/circuit_specific_setup_compiler.rs
@@ -12,7 +12,7 @@ use crate::{
     Error, PhantomData,
 };
 use ark_pcd::PCD;
-use rand::{CryptoRng, RngCore};
+use ark_std::rand::{CryptoRng, RngCore};
 
 /// compiler for circuit-specifict setup IVLS
 pub struct CircuitSpecificSetupIVLSCompiler<VC: VerifiableTransitionFunctionConfig> {

--- a/src/compiler/universal_setup_compiler.rs
+++ b/src/compiler/universal_setup_compiler.rs
@@ -12,8 +12,8 @@ use crate::{
     Error, PhantomData,
 };
 use ark_pcd::UniversalSetupPCD;
-use rand::prelude::StdRng;
-use rand::{CryptoRng, RngCore, SeedableRng};
+use ark_std::rand::rngs::StdRng;
+use ark_std::rand::{CryptoRng, RngCore, SeedableRng};
 
 /// compiler for universal setup IVLS
 pub struct UniversalSetupIVLSCompiler<VC: VerifiableTransitionFunctionConfig>

--- a/src/ivls/transition_function.rs
+++ b/src/ivls/transition_function.rs
@@ -14,8 +14,8 @@ use crate::{
 };
 use ark_pcd::{PCDPredicate, PCD};
 use ark_relations::r1cs::ConstraintSystemRef;
+use ark_std::rand::CryptoRng;
 use ark_std::vec;
-use rand::CryptoRng;
 
 /// a collection of types for an IVLS
 pub trait VerifiableTransitionFunctionConfig: Sized {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,11 +27,11 @@ pub(crate) use ark_std::{boxed::Box, vec::Vec};
 
 pub(crate) use ark_ff::{Field, PrimeField, ToBytes};
 pub(crate) use ark_relations::r1cs::SynthesisError;
+pub(crate) use ark_std::rand::RngCore;
 pub(crate) use ark_std::{
     borrow::Borrow,
     marker::{PhantomData, Sized},
 };
-pub(crate) use rand::RngCore;
 
 /// wrapped error types
 pub type Error = Box<dyn ark_std::error::Error>;


### PR DESCRIPTION
This PR removes the direct use of `rand` and instead uses `ark_std::rand`. This is aimed to push https://github.com/arkworks-rs/utils/pull/24.